### PR TITLE
make ImportDirectorResources extension check (aspx|ascx|master|sitemap|)...

### DIFF
--- a/Westwind.Globalization/SupportClasses/DbResXConverter.cs
+++ b/Westwind.Globalization/SupportClasses/DbResXConverter.cs
@@ -622,7 +622,7 @@ namespace Westwind.Globalization
                 if (tokens.Length > 1)
                 {
                     string extension = tokens[1];
-                    if ("aspx|ascx|master|sitemap|".Contains(extension + "|") )
+                    if ("aspx|ascx|master|sitemap|".Contains(extension.ToLower() + "|") )
                         resName += "." + extension;
                     else
                         localeId = extension;


### PR DESCRIPTION
... case insensitive (e.g. for importing resources files such as Global.Master.Resx).

Importing fails where a resource file name split has more than one token and the extension casing doesn't match string compare.
