### PR TITLE
Add ResourceSet query param filter for js caching

### DIFF
--- a/Westwind.Globalization/SupportClasses/JavaScriptResourceHandler.cs
+++ b/Westwind.Globalization/SupportClasses/JavaScriptResourceHandler.cs
@@ -150,6 +150,7 @@ namespace Westwind.Globalization
             // OutputCache settings
             HttpCachePolicy cache = Response.Cache;
 
+            cache.VaryByParams["ResourceSet"] = true;
             cache.VaryByParams["LocaleId"] = true;
             cache.VaryByParams["ResoureType"] = true;
             cache.VaryByParams["IncludeControls"] = true;


### PR DESCRIPTION
This looked like a bug to me. Adding this line got Javascript resource handling from multiple pages working again. 
