### PR TITLE
Removed filegroups to make create script Azure SQL compatible.

### DIFF
--- a/Westwind.Globalization/DbResourceSupportClasses/DbResourceDataManager.cs
+++ b/Westwind.Globalization/DbResourceSupportClasses/DbResourceDataManager.cs
@@ -1438,16 +1438,14 @@ CREATE TABLE [{0}] (
 		[BinFile]         varbinary(max) NULL,
 		[TextFile]        nvarchar(max) NULL,
 		[Filename]        nvarchar(128) NULL,
-        [Comment]         nvarchar(512) NULL
+		[Comment]         nvarchar(512) NULL
 )
-ON [PRIMARY]
 GO
 ALTER TABLE [{0}]
 	ADD
 	CONSTRAINT [PK_{0}]
 	PRIMARY KEY
 	([pk])
-	ON [PRIMARY]
 GO
 ALTER TABLE [{0}]
 	ADD


### PR DESCRIPTION
This is a small change in the sql table creation script. Filegroups are not support in SQL Azure and this was the only change mandatory to get it working.