### PR TITLE
Make access to DbResourceConfiguration.LoadedProviders thread-safe.

### DIFF
--- a/Westwind.Globalization/DbResourceManagerResourceProvider/DbResourceProvider.cs
+++ b/Westwind.Globalization/DbResourceManagerResourceProvider/DbResourceProvider.cs
@@ -86,7 +86,7 @@ namespace Westwind.Globalization
             {
                 //  _virtualPath = virtualPath;
                 _className = classname;
-                DbResourceConfiguration.LoadedProviders.Add(this);
+                DbResourceConfiguration.AddProvider(this);
             }
         }
 

--- a/Westwind.Globalization/DbSimpleResourceProvider/DbSimpleResourceProvider.cs
+++ b/Westwind.Globalization/DbSimpleResourceProvider/DbSimpleResourceProvider.cs
@@ -114,7 +114,7 @@ namespace Westwind.Globalization
             {
                 ProviderLoaded = true;
                 _ResourceSetName = className;
-                DbResourceConfiguration.LoadedProviders.Add(this);
+                DbResourceConfiguration.AddProvider(this);
             }
               
         }


### PR DESCRIPTION
Attempt to resolve following exception:

[IndexOutOfRangeException: Index was outside the bounds of the array.]
   System.Collections.Generic.List`1.Add(T item) +48
   Westwind.Globalization.DbSimpleResourceProviderFactory.CreateGlobalResourceProvider(String classname) +78
   System.Web.Compilation.ResourceExpressionBuilder.GetGlobalResourceObject(String classKey, String resourceKey, Type objType, String propName, CultureInfo culture) +186
... (I trimmed the rest of the stack trace)
