### PR TITLE
Modifications to allow accessing a resource for a Culture that is not…

### DIFF
--- a/Westwind.Globalization.Web/Properties/AssemblyInfo.cs
+++ b/Westwind.Globalization.Web/Properties/AssemblyInfo.cs
@@ -37,5 +37,5 @@ using System.Web.UI;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.12.0")]
-[assembly: AssemblyFileVersion("2.12.0")]
+[assembly: AssemblyVersion("2.12.1")]
+[assembly: AssemblyFileVersion("2.12.1")]

--- a/Westwind.Globalization/DbResourceManager/DbRes.cs
+++ b/Westwind.Globalization/DbResourceManager/DbRes.cs
@@ -114,13 +114,7 @@ namespace Westwind.Globalization
             if (manager == null)
                 return resId;
 
-            CultureInfo ci;
-            if (string.IsNullOrEmpty(lang))
-                ci = CultureInfo.CurrentUICulture;
-            else
-                ci = new CultureInfo(lang);
-
-            string result = manager.GetObject(resId, ci) as string;
+            string result = manager.GetObject(resId, lang) as string;
 
             if (string.IsNullOrEmpty(result))
                 return resId;
@@ -272,7 +266,7 @@ namespace Westwind.Globalization
         /// </summary>
         /// <param name="resourceSet"></param>
         /// <returns></returns>
-        public static ResourceManager GetResourceManager(string resourceSet)
+        public static DbResourceManager GetResourceManager(string resourceSet)
         {            
             // check if the res manager exists
             DbResourceManager manager = null;
@@ -314,7 +308,7 @@ namespace Westwind.Globalization
             else if (lang == string.Empty)
                 ci = CultureInfo.InvariantCulture;
             else
-                ci = new CultureInfo(lang);
+                return manager.GetResourceSet(lang, false, false);
 
             return manager.GetResourceSet(ci, false, true);
         }

--- a/Westwind.Globalization/DbResourceManager/DbResourceManager.cs
+++ b/Westwind.Globalization/DbResourceManager/DbResourceManager.cs
@@ -266,7 +266,7 @@ namespace Westwind.Globalization
                 var lastDashIndex = cultureName.LastIndexOf('-');
                 if (lastDashIndex != -1)
                 {
-                    fallbackCultureName = cultureName.Substring(0, cultureName.Length - lastDashIndex + 1);
+                    fallbackCultureName = cultureName.Substring(0, lastDashIndex);
                 }
             }
 

--- a/Westwind.Globalization/DbResourceManager/DbResourceReader.cs
+++ b/Westwind.Globalization/DbResourceManager/DbResourceReader.cs
@@ -56,7 +56,7 @@ namespace Westwind.Globalization
         /// <summary>
         /// The culture that applies to to this reader
         /// </summary>
-        private CultureInfo cultureInfo;
+        private string cultureName;
 
         /// <summary>
         /// Cached instance of items. The ResourceManager will often be called repeatedly
@@ -78,8 +78,14 @@ namespace Westwind.Globalization
         /// <param name="cultureInfo">The CultureInfo identifying the culture of the resources to be read</param>
         public DbResourceReader(string baseNameField, CultureInfo cultureInfo)
         {
+          this.baseNameField = baseNameField;
+	        cultureName = cultureInfo.Name;
+        }
+
+        public DbResourceReader(string baseNameField, string cultureName)
+        {
             this.baseNameField = baseNameField;
-            this.cultureInfo = cultureInfo;
+            this.cultureName = cultureName;
         }
 
         /// <summary>
@@ -111,7 +117,7 @@ namespace Westwind.Globalization
                 // Here's the only place we really access the database and return
                 // a specific ResourceSet for a given ResourceSet Id and Culture
                 DbResourceDataManager manager = DbResourceDataManager.CreateDbResourceDataManager();
-                Items = manager.GetResourceSet(cultureInfo.Name, baseNameField);
+                Items = manager.GetResourceSet(cultureName, baseNameField);
                 return Items.GetEnumerator();
             }
         }

--- a/Westwind.Globalization/DbResourceManager/DbResourceSet.cs
+++ b/Westwind.Globalization/DbResourceManager/DbResourceSet.cs
@@ -50,7 +50,7 @@ namespace Westwind.Globalization
     public class DbResourceSet : ResourceSet
     {
         string _BaseName = null;
-        CultureInfo _Culture = null;
+        string _CultureName = String.Empty;
 
         /// <summary>
         /// Core constructore. Gets passed a baseName (which is the ResourceSet Id - 
@@ -66,7 +66,14 @@ namespace Westwind.Globalization
             : base(new DbResourceReader(baseName, culture))
         {
             _BaseName = baseName;
-            _Culture = culture;
+            _CultureName = culture.Name;
+        }
+
+        public DbResourceSet(string baseName, string cultureName)
+            : base(new DbResourceReader(baseName, cultureName))
+        {
+            _BaseName = baseName;
+            _CultureName = cultureName;
         }
 
         /// <summary>

--- a/Westwind.Globalization/Properties/AssemblyInfo.cs
+++ b/Westwind.Globalization/Properties/AssemblyInfo.cs
@@ -37,5 +37,5 @@ using System.Web.UI;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.12.0")]
-[assembly: AssemblyFileVersion("2.12.0")]
+[assembly: AssemblyVersion("2.12.1")]
+[assembly: AssemblyFileVersion("2.12.1")]

--- a/Westwind.Globalization/Utilities/DbResXConverter.cs
+++ b/Westwind.Globalization/Utilities/DbResXConverter.cs
@@ -902,7 +902,7 @@ namespace Westwind.Globalization
         if (type == null)
             return null;
 
-        var resMan = new ResourceManager(resourceSetName, type.Assembly);
+        var resMan = new DbResourceManager(resourceSetName, type.Assembly);
         if (resMan == null)
             return null;
 
@@ -910,17 +910,17 @@ namespace Westwind.Globalization
     }
 
 
-    public Dictionary<string, object> GetResourcesNormalizedForLocale(ResourceManager resourceManager, string localeId)
+    public Dictionary<string, object> GetResourcesNormalizedForLocale(DbResourceManager resourceManager, string localeId)
     {        
         var resDict = new Dictionary<string, object>();
 
-        var culture = Thread.CurrentThread.CurrentUICulture;
-        if (localeId == null)
-            culture = CultureInfo.CurrentUICulture;
-        else if(localeId == string.Empty)
-            culture = CultureInfo.InvariantCulture;
-        else if (culture.IetfLanguageTag != localeId)
-            culture = CultureInfo.GetCultureInfoByIetfLanguageTag(localeId);
+        //var culture = Thread.CurrentThread.CurrentUICulture;
+        //if (localeId == null)
+        //    culture = CultureInfo.CurrentUICulture;
+        //else if(localeId == string.Empty)
+        //    culture = CultureInfo.InvariantCulture;
+        //else if (culture.IetfLanguageTag != localeId)
+        //    culture = CultureInfo.GetCultureInfoByIetfLanguageTag(localeId);
         
         try
         {
@@ -935,7 +935,7 @@ namespace Westwind.Globalization
             var keys = resDict.Keys.ToList();
             foreach (var key in keys)
             {
-                resDict[key] = resourceManager.GetObject(key,culture);
+                resDict[key] = resourceManager.GetObject(key, localeId);
             }            
         }
         catch (Exception ex)

--- a/Westwind.Globalization/Utilities/GeneratedResourceHelper.cs
+++ b/Westwind.Globalization/Utilities/GeneratedResourceHelper.cs
@@ -48,6 +48,11 @@ namespace Westwind.Globalization
     /// </summary>
     public static class GeneratedResourceHelper
     {
+        /// <summary>
+        /// Allows setting the Culture to be used for strongly typed resource lookups 
+        /// by name rather than usign the CurrentUiCulture 
+        /// </summary>
+        [ThreadStatic] public static string CurrentCulture;
 
         /// <summary>
         /// Helper function called from strongly typed resources to retrieve 
@@ -70,7 +75,7 @@ namespace Westwind.Globalization
             if (resourceMode == ResourceAccessMode.Resx)
                 return manager.GetString(resourceId);
 
-            return DbRes.T(resourceId, resourceSet);
+            return DbRes.T(resourceId, resourceSet, CurrentCulture);
         }
 
         /// <summary>
@@ -93,7 +98,7 @@ namespace Westwind.Globalization
                 return GetAspNetResourceProviderValue(resourceSet, resourceId);
             if (resourceMode == ResourceAccessMode.Resx)
                 return manager.GetObject(resourceId);
-            return DbRes.TObject(resourceId, resourceSet);
+            return DbRes.TObject(resourceId, resourceSet, CurrentCulture);
         }
 
 


### PR DESCRIPTION
… registered in the system. The specified culture must still have a registered culture (or invariant culture) as its parent to allow fall-back in the case of missing resources.

This solves the specific case of needing to use a custom culture (for example to do per client translation for a multi-client system) when hosting on a system that does not allow registering custom CultureInfo. For example on Azure web apps.
