### PR TITLE
Implement a factory for ResourceReaders and use it in DBResourceManager

### DIFF
--- a/src/NetCore/Westwind.Globalization.AspnetCore/Controllers/LocalizationAdministrationController.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/Controllers/LocalizationAdministrationController.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -45,7 +44,7 @@ namespace Westwind.Globalization.Administration
         {
             Host = host;
             Config = config;
-            DbIRes = new DbResInstance(config);
+            DbIRes = new DbResInstance(new DBResourceReaderFactory(), config);
             Manager = DbResourceDataManager.CreateDbResourceDataManager(config.DbResourceDataManagerType);
         }
 

--- a/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResHtmlLocalizer.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResHtmlLocalizer.cs
@@ -12,16 +12,15 @@ namespace Westwind.Globalization.AspnetCore
     {
         DbResInstance DbRes { get; }
 
-        DbResourceConfiguration Config { get; }
-
         public string ResourceSet { get; set; } = "Resources";
 
-        public DbResHtmlLocalizer(DbResourceConfiguration config)
-        {
-            DbRes = new DbResInstance(config);
-            Config = config;
-        }
+        private IHtmlLocalizerFactory HtmlLocalizerFactory { get; }
 
+        public DbResHtmlLocalizer(DbResInstance dbRes, IHtmlLocalizerFactory htmlLocalizerFactory)
+        {
+            DbRes = dbRes ?? throw new System.ArgumentNullException(nameof(dbRes));
+            HtmlLocalizerFactory = htmlLocalizerFactory ?? throw new System.ArgumentNullException(nameof(htmlLocalizerFactory));
+        }
 
         public LocalizedString GetString(string name)
         {
@@ -48,7 +47,6 @@ namespace Westwind.Globalization.AspnetCore
 
                     var localizedString = new LocalizedString(key, value);
                     yield return localizedString;
-
                 }
             }
         }
@@ -56,7 +54,7 @@ namespace Westwind.Globalization.AspnetCore
         public IHtmlLocalizer WithCulture(CultureInfo culture)
         {
             CultureInfo.DefaultThreadCurrentUICulture = culture;
-            return new DbResHtmlLocalizer(Config);
+            return HtmlLocalizerFactory.Create(ResourceSet, null);
         }
 
         LocalizedHtmlString IHtmlLocalizer.this[string name]

--- a/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResHtmlLocalizerFactory.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResHtmlLocalizerFactory.cs
@@ -6,13 +6,15 @@ namespace Westwind.Globalization.AspnetCore
 {
     public class DbResHtmlLocalizerFactory : IHtmlLocalizerFactory
     {
-        private IHostingEnvironment _host;
+        private readonly IResourceReaderFactory _resourceReaderFactory;
+		private IHostingEnvironment _host;
         private DbResourceConfiguration _config;
 
-        public DbResHtmlLocalizerFactory(DbResourceConfiguration config, IHostingEnvironment env)
+        public DbResHtmlLocalizerFactory(DbResourceConfiguration config, IHostingEnvironment env, IResourceReaderFactory resourceReaderFactory)
         {
             _config = config;
             _host = env;
+            _resourceReaderFactory = resourceReaderFactory ?? throw new ArgumentNullException(nameof(resourceReaderFactory));
         }
 
 
@@ -23,12 +25,13 @@ namespace Westwind.Globalization.AspnetCore
         /// <param name="location"></param>
         /// <returns></returns>
         public IHtmlLocalizer Create(string baseName, string location)
-        {           
+        {       
             // strip off application base (location) if it's provided
             if (baseName != null && baseName.StartsWith(location))
                 baseName = baseName.Substring(location.Length + 1);
-            
-            return new DbResHtmlLocalizer(_config) { ResourceSet = baseName };
+
+            var resInstance = new DbResInstance(_resourceReaderFactory, _config);
+            return new DbResHtmlLocalizer(resInstance, this) { ResourceSet = baseName };
         }
 
 

--- a/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResStringLocalizer.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResStringLocalizer.cs
@@ -16,21 +16,21 @@ namespace Westwind.Globalization.AspnetCore
     {        
         DbResInstance DbRes { get;   }
 
-        DbResourceConfiguration Config { get;  }
-
         /// <summary>
         /// Default ResourceSetName if no Template type is provided
         /// </summary>
         public string ResourceSet { get; set; }
 
-        public DbResStringLocalizer(DbResourceConfiguration config)
+        public IStringLocalizerFactory StringLocalizerFactory { get; }
+
+        public DbResStringLocalizer(DbResourceConfiguration config, DbResInstance dbRes, IStringLocalizerFactory stringLocalizerFactory)
         {
-            DbRes = new DbResInstance(config);
-            Config = config;
-            
+            DbRes = dbRes;
+
             // default
-            ResourceSet = Config.StringLocalizerResourcePath + ".CommonResources";
-        }
+            ResourceSet = config.StringLocalizerResourcePath + ".CommonResources";
+            StringLocalizerFactory = stringLocalizerFactory ?? throw new System.ArgumentNullException(nameof(stringLocalizerFactory));
+		}
 
 
         public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures)
@@ -53,7 +53,7 @@ namespace Westwind.Globalization.AspnetCore
         public IStringLocalizer WithCulture(CultureInfo culture)
         {
             CultureInfo.DefaultThreadCurrentUICulture = culture;
-            return new DbResStringLocalizer(Config);            
+            return StringLocalizerFactory.Create(ResourceSet, null);
         }
 
         LocalizedString IStringLocalizer.this[string name]

--- a/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResStringLocalizerFactory.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResStringLocalizerFactory.cs
@@ -8,13 +8,14 @@ namespace Westwind.Globalization.AspnetCore
     {
         private DbResourceConfiguration _config;
         private IHostingEnvironment _host;
+        private readonly IResourceReaderFactory _resourceReaderFactory;
 
-        public DbResStringLocalizerFactory(DbResourceConfiguration config, IHostingEnvironment host)            
+        public DbResStringLocalizerFactory(DbResourceConfiguration config, IHostingEnvironment host, IResourceReaderFactory resourceReaderFactory)
         {
             _config = config;
             _host = host;
+            _resourceReaderFactory = resourceReaderFactory ?? throw new ArgumentNullException(nameof(resourceReaderFactory));
         }
-        
 
         public IStringLocalizer Create(string baseName, string location)
         {
@@ -22,13 +23,14 @@ namespace Westwind.Globalization.AspnetCore
             if (baseName != null && baseName.StartsWith(location))
                 baseName = baseName.Substring(location.Length + 1);
 
-            return new DbResStringLocalizer(_config) { ResourceSet = baseName };
+            var dbResInstance = new DbResInstance(_resourceReaderFactory, _config);
+            return new DbResStringLocalizer(_config, dbResInstance, this) { ResourceSet = baseName };
         }
 
         public IStringLocalizer Create(Type resourceSource)
-        {                        
+        {            
             string baseName = resourceSource.FullName;                             
             return Create(baseName, _host.ApplicationName);
-        }        
+        }
     }
 }

--- a/src/NetCore/Westwind.Globalization.AspnetCore/WestwindGlobalizationStartupConfiguration.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/WestwindGlobalizationStartupConfiguration.cs
@@ -50,6 +50,8 @@ namespace Westwind.Globalization.AspnetCore
             // register with DI
             services.AddSingleton(config);
 
+            services.AddSingleton<IResourceReaderFactory, DBResourceReaderFactory>();
+
             return services;
         }
     }

--- a/src/Westwind.Globalization/DbResourceManager/DBResourceReaderFactory.cs
+++ b/src/Westwind.Globalization/DbResourceManager/DBResourceReaderFactory.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+using System.Resources;
+
+namespace Westwind.Globalization
+{
+	/// <summary>
+	/// Creates instances of <see cref="DbResourceReader"/>s for a given <see cref="ResourceSet"/> and <see cref="CultureInfo"/>.
+	/// </summary>
+	public class DBResourceReaderFactory : IResourceReaderFactory
+	{
+		/// <inheritdoc />
+		public IResourceReader Create(string resourceSet, CultureInfo culture, DbResourceConfiguration config)
+		{
+			return new DbResourceReader(resourceSet, culture, config);
+		}
+	}
+}

--- a/src/Westwind.Globalization/DbResourceManager/DbRes.cs
+++ b/src/Westwind.Globalization/DbResourceManager/DbRes.cs
@@ -65,7 +65,7 @@ namespace Westwind.Globalization
 
         static DbRes()
         {
-            Instance = new DbResInstance(DbResourceConfiguration.Current);
+            Instance = new DbResInstance(new DBResourceReaderFactory(), DbResourceConfiguration.Current);
         }
 
         /// <summary>

--- a/src/Westwind.Globalization/DbResourceManager/DbResInstance.cs
+++ b/src/Westwind.Globalization/DbResourceManager/DbResInstance.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /*
  **************************************************************
  *  Author: Rick Strahl 
@@ -36,6 +36,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Resources;
 using System.Web;
+using System.Reflection;
 
 namespace Westwind.Globalization
 {
@@ -65,6 +66,8 @@ namespace Westwind.Globalization
         protected static Dictionary<string, DbResourceManager> ResourceManagers =
             new Dictionary<string, DbResourceManager>();
 
+        public IResourceReaderFactory ResourceReaderFactory { get; }
+
         /// <summary>
         /// Determines whether resources that fail in a lookup are automatically
         /// added to the resource table
@@ -73,13 +76,20 @@ namespace Westwind.Globalization
 
         public DbResourceConfiguration Configuration { get; set; }
 
-        public DbResInstance(DbResourceConfiguration configuration = null)
+        private DbResInstance(DbResourceConfiguration configuration = null)
         {
             AutoAddResources = DbResourceConfiguration.Current.AddMissingResources;
             if (Configuration != null)
                 Configuration = configuration;
             else
                 Configuration = DbResourceConfiguration.Current;
+
+            ResourceReaderFactory = new DBResourceReaderFactory();
+        }
+
+        public DbResInstance(IResourceReaderFactory resourceReaderFactory, DbResourceConfiguration configuration = null) : this(configuration)
+        {
+            ResourceReaderFactory = resourceReaderFactory ?? throw new ArgumentNullException(nameof(resourceReaderFactory));
         }
 
         /// <summary>
@@ -345,7 +355,7 @@ namespace Westwind.Globalization
                     ResourceManagers.TryGetValue(resourceSet, out manager);
                     if (manager == null)
                     {
-                        manager = new DbResourceManager(resourceSet);
+                        manager = new DbResourceManager(resourceSet, ResourceReaderFactory);
                         ResourceManagers.Add(resourceSet, manager);
                     }
                 }

--- a/src/Westwind.Globalization/DbResourceManager/DbResourceManager.cs
+++ b/src/Westwind.Globalization/DbResourceManager/DbResourceManager.cs
@@ -83,6 +83,7 @@ namespace Westwind.Globalization
         /// </summary>
         private static readonly object SyncLock = new object();
         private static readonly object AddSyncLock = new object();
+        private readonly IResourceReaderFactory _resourceReaderFactory;
 
         /// <summary>
         /// If true causes any entries that aren't found to be added
@@ -130,6 +131,17 @@ namespace Westwind.Globalization
         public DbResourceManager(string baseName, Assembly assembly, Type resourceType)  
         {
             Initialize(baseName, assembly);
+        }
+
+        /// <summary>
+        /// Creates an instance of a DbResourceManager. Allows to specify a <see cref="IResourceReaderFactory"/> to change
+        /// the default ResourceReader.
+        /// </summary>
+        /// <param name="baseName"></param>
+        /// <param name="resourceReaderFactory"></param>
+        internal DbResourceManager(string baseName, IResourceReaderFactory resourceReaderFactory) : this(baseName)
+        {
+            _resourceReaderFactory = resourceReaderFactory ?? throw new ArgumentNullException(nameof(resourceReaderFactory));
         }
 
         /// <summary>
@@ -182,7 +194,8 @@ namespace Westwind.Globalization
                     return InternalResourceSets[culture.Name];
             
                 // Otherwise create a new instance, load it and return it
-                DbResourceSet rs = new DbResourceSet(ResourceSetName, culture, Configuration);
+                IResourceReader reader = _resourceReaderFactory.Create(ResourceSetName, culture, Configuration);
+                DbResourceSet rs = new DbResourceSet(reader);
                 
                 // Add the resource set to the cached set
                 InternalResourceSets.Add(culture.Name, rs);

--- a/src/Westwind.Globalization/DbResourceManager/DbResourceManager.cs
+++ b/src/Westwind.Globalization/DbResourceManager/DbResourceManager.cs
@@ -83,7 +83,8 @@ namespace Westwind.Globalization
         /// </summary>
         private static readonly object SyncLock = new object();
         private static readonly object AddSyncLock = new object();
-        private readonly IResourceReaderFactory _resourceReaderFactory;
+
+        private IResourceReaderFactory _resourceReaderFactory;
 
         /// <summary>
         /// If true causes any entries that aren't found to be added
@@ -167,8 +168,11 @@ namespace Westwind.Globalization
             AutoAddMissingEntries = DbResourceConfiguration.Current.AddMissingResources;
             
             // InternalResourceSets contains a set of resources for each locale
-            InternalResourceSets = new Dictionary<string, ResourceSet>();            
-        }
+            InternalResourceSets = new Dictionary<string, ResourceSet>();
+
+			// Default to the DBResourceReaderFactory
+			_resourceReaderFactory = new DBResourceReaderFactory();
+		}
                 
         
 

--- a/src/Westwind.Globalization/DbResourceManager/DbResourceSet.cs
+++ b/src/Westwind.Globalization/DbResourceManager/DbResourceSet.cs
@@ -49,8 +49,9 @@ namespace Westwind.Globalization
     /// calls into the database to retrieve the resources for the ResourceSet.
     /// </summary>
     public class DbResourceSet : ResourceSet
-    {        
-        
+    {
+		private readonly Type _readerType;
+
         /// <summary>
         /// Core constructor. Gets passed a baseName (which is the ResourceSet Id - 
         /// either a local or global resource group) and a culture. 
@@ -64,7 +65,13 @@ namespace Westwind.Globalization
         /// <param name="configuration"></param>
         public DbResourceSet(string baseName, CultureInfo culture, DbResourceConfiguration configuration) 
             : base(new DbResourceReader(baseName, culture, configuration))
-        {            
+        {
+            _readerType = typeof(DbResourceReader);
+		}
+
+        public DbResourceSet(IResourceReader resourceReader) : base(resourceReader)
+        {
+            _readerType = resourceReader.GetType();
         }
 
         /// <summary>
@@ -74,7 +81,7 @@ namespace Westwind.Globalization
         /// <returns></returns>
         public override Type GetDefaultReader()
         {
-            return typeof(DbResourceReader);
+            return _readerType;
         }
 
         /// <summary>

--- a/src/Westwind.Globalization/DbResourceSupportClasses/IResourceReaderFactory.cs
+++ b/src/Westwind.Globalization/DbResourceSupportClasses/IResourceReaderFactory.cs
@@ -1,0 +1,21 @@
+﻿using System.Globalization;
+using System.Resources;
+
+namespace Westwind.Globalization
+{
+	/// <summary>
+	/// Factory that creates instances of <see cref="IResourceReader"/> for a specific <see cref="ResourceSet"/>
+	/// and <see cref="CultureInfo">culture</see>.
+	/// </summary>
+	public interface IResourceReaderFactory
+    {
+		/// <summary>
+		/// Create a <see cref="IResourceReader"/> instance for the given <see cref="CultureInfo"/>.
+		/// </summary>
+		/// <param name="resourceSet">ResourceSet name to create the reader for.</param>
+		/// <param name="culture">Culture for which the resource reader should be created.</param>
+		/// <param name="config"><see cref="DbResourceConfiguration"/> to further configure the reader.</param>
+		/// <returns>Instance of an IResourceReader</returns>
+		IResourceReader Create(string resourceSet, CultureInfo culture, DbResourceConfiguration config);
+	}
+}


### PR DESCRIPTION
This PR contains a proposal for using a factory for creating instances of IResourceReader instead of
newing up instances of DbResourceReader fix in the ResourceSet. This allows to read resources from other sources than the databases supported directly within the Westwind.Globalization package. In my case I use a REST API to get translated ResourceSets.

I tried to make the changes backward compatible. So the default implementation of the factory still produces a DBResourceReader instance. Also the default factory is registered in the "AddWestwindGlobalization" Extension for AspNetCore projects. The classes that need an instance of the factory create the default factory if none is given.

This PR was made due to the request in issue #122. Please let me know what you think of this. What changes would be necessary to accept the PR?

Thank you,
Philipp