### PR TITLE
Added Ignore AntiforgeryToken Attribute to LocalizationAdministrationController

### DIFF
--- a/src/NetCore/Westwind.Globalization.AspnetCore/Controllers/LocalizationAdministrationController.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/Controllers/LocalizationAdministrationController.cs
@@ -23,6 +23,7 @@ namespace Westwind.Globalization.Administration
     /// Form. This service is self contained.
     /// </summary>
     [Route("api/LocalizationAdministration")]
+    [IgnoreAntiforgeryToken]
     [UnhandledApiExceptionFilter]        
     public class LocalizationAdministrationController : Controller
     {


### PR DESCRIPTION
Ran into an issue where the localization gui was breaking because our asp.net core app has [AutoValidateAntiforgeryToken ](https://docs.microsoft.com/en-us/aspnet/core/security/anti-request-forgery#autovalidateantiforgerytoken) enabled globally.

Couldn't come up with a better solution other than just adding the ignore attribute to the localization controller, no harm in adding the attribute even if you don't have the auto validate functionality enabled. 