### PR TITLE
Fix wrong ResourceSet after WithCulture

### DIFF
--- a/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResHtmlLocalizer.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResHtmlLocalizer.cs
@@ -56,7 +56,7 @@ namespace Westwind.Globalization.AspnetCore
         public IHtmlLocalizer WithCulture(CultureInfo culture)
         {
             CultureInfo.DefaultThreadCurrentUICulture = culture;
-            return new DbResHtmlLocalizer(Config);
+            return new DbResHtmlLocalizer(Config) { ResourceSet = ResourceSet};
         }
 
         LocalizedHtmlString IHtmlLocalizer.this[string name]

--- a/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResStringLocalizer.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/Localizers/DbResStringLocalizer.cs
@@ -53,7 +53,7 @@ namespace Westwind.Globalization.AspnetCore
         public IStringLocalizer WithCulture(CultureInfo culture)
         {
             CultureInfo.DefaultThreadCurrentUICulture = culture;
-            return new DbResStringLocalizer(Config);            
+            return new DbResStringLocalizer(Config) { ResourceSet = ResourceSet };            
         }
 
         LocalizedString IStringLocalizer.this[string name]

--- a/src/NetCore/Westwind.Globalization.Test.AspnetCore/DbResHtmlLocalizerTests.cs
+++ b/src/NetCore/Westwind.Globalization.Test.AspnetCore/DbResHtmlLocalizerTests.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Westwind.Globalization.AspnetCore;
+
+namespace Westwind.Globalization.Test.AspnetCore
+{
+    [TestFixture]
+    public class DbResHtmlLocalizerTests
+    {
+        [Test]
+        public void ResourceSetRemainsOnWithCultureCall()
+        {
+            var localizer = new DbResHtmlLocalizer(new DbResourceConfiguration()) { ResourceSet = "Test" };
+            var newCultureLocalizer = (DbResHtmlLocalizer)localizer.WithCulture(new System.Globalization.CultureInfo("en-US"));
+
+            Assert.AreEqual(localizer.ResourceSet, newCultureLocalizer.ResourceSet);
+        }
+    }
+}

--- a/src/NetCore/Westwind.Globalization.Test.AspnetCore/DbResStringLocalizerTests.cs
+++ b/src/NetCore/Westwind.Globalization.Test.AspnetCore/DbResStringLocalizerTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+using Westwind.Globalization.AspnetCore;
+
+namespace Westwind.Globalization.Test.AspnetCore
+{
+    [TestFixture]
+    public class DbResStringLocalizerTests
+    {
+        [Test]
+        public void ResourceSetRemainsOnWithCultureCall()
+        {
+            var localizer = new DbResStringLocalizer(new DbResourceConfiguration()) { ResourceSet = "Test" };
+            var newCultureLocalizer = (DbResStringLocalizer)localizer.WithCulture(new System.Globalization.CultureInfo("en-US"));
+
+            Assert.AreEqual(localizer.ResourceSet, newCultureLocalizer.ResourceSet);
+        }
+    }
+}


### PR DESCRIPTION
Sets the ResourceSet on the WithCulture methods.
Fixes #138 