### PR TITLE
Provide NeedsUpdate property on resourceIds to assist translators

### DIFF
--- a/src/NetCore/Westwind.Globalization.AspnetCore/Controllers/LocalizationAdministrationController.cs
+++ b/src/NetCore/Westwind.Globalization.AspnetCore/Controllers/LocalizationAdministrationController.cs
@@ -22,7 +22,7 @@ namespace Westwind.Globalization.Administration
     /// Form. This service is self contained.
     /// </summary>
     [Route("api/LocalizationAdministration")]
-    [UnhandledApiExceptionFilter]        
+    [UnhandledApiExceptionFilter]
     public class LocalizationAdministrationController : Controller
     {
         public const string STR_RESOURCESET = "LocalizationForm";
@@ -55,14 +55,14 @@ namespace Westwind.Globalization.Administration
         public override void OnActionExecuting(ActionExecutingContext context)
         {
             base.OnActionExecuting(context);
-            
+
             if (DbIRes.Configuration.OnAuthorizeLocalizationAdministration != null)
             {
                 var func = Config.OnAuthorizeLocalizationAdministration as Func<ActionExecutingContext, bool>;
                 if  (func != null)
-                {                                     
-                    if (!func.Invoke(context))                    
-                        throw new UnauthorizedAccessException();                    
+                {
+                    if (!func.Invoke(context))
+                        throw new UnauthorizedAccessException();
                 }
             }
         }
@@ -74,22 +74,22 @@ namespace Westwind.Globalization.Administration
         //public IEnumerable<ResourceIdItem> GetResourceList(string resourceSet)
         public ActionResult GetResourceList(string resourceSet)
         {
-            var ids = Manager.GetAllResourceIds(resourceSet);
+            var ids = Manager.GetAllResourceIds(resourceSet, "");
             if (ids == null)
                 throw new ApplicationException(DbIRes.T("ResourceSetLoadingFailed", STR_RESOURCESET) + ":" +
                                                Manager.ErrorMessage);
 
-            
+
             //return ids;
             return Json(ids, jsonSettings);
         }
 
 
-   
+
         /// <summary>
         /// Returns a shaped objects that can be displayed in an editable grid the grid view for locale ids
         /// of resources.
-        /// 
+        ///
         //{
         //  "Locales": [
         //    "",
@@ -163,7 +163,7 @@ namespace Westwind.Globalization.Administration
                             {
                                 ResourceId = resid,
                                 LocaleId = locale,
-                                ResourceSet = resourceSet                                
+                                ResourceSet = resourceSet
                             });
                         }
                     }
@@ -193,16 +193,17 @@ namespace Westwind.Globalization.Administration
                 Resources = resultList
             };
 
-            return Json(result, jsonSettings);            
+            return Json(result, jsonSettings);
         }
 
 
         [HttpGet]
         [Route("GetResourceListHtml")]
-        public JsonResult GetResourceListHtml(string resourceSet)
+        public JsonResult GetResourceListHtml(string resourceSet, string localeId)
         //public IEnumerable<ResourceIdListItem> GetResourceListHtml(string resourceSet)
         {
-            var ids = Manager.GetAllResourceIdListItems(resourceSet);
+            localeId = localeId == null ? "" : localeId;
+            var ids = Manager.GetAllResourceIdListItems(resourceSet, localeId);
             if (ids == null)
                 throw new ApplicationException(DbIRes.T("ResourceSetLoadingFailed", STR_RESOURCESET) + ":" +
                                                Manager.ErrorMessage);
@@ -228,7 +229,7 @@ namespace Westwind.Globalization.Administration
         /// Returns a list of the all the LocaleIds used in a given resource set
         /// </summary>
         /// <param name="resourceSet"></param>
-        /// <returns></returns>        
+        /// <returns></returns>
         [Route("GetLocaleIds")]
         public JsonResult GetAllLocaleIds(string resourceSet)
         // public IEnumerable<object> GetAllLocaleIds(string resourceSet)
@@ -288,8 +289,8 @@ namespace Westwind.Globalization.Administration
         //public IEnumerable<ResourceItemEx> GetResourceItems([FromBody] dynamic  parm)
         {
             string resourceSet = parm.ResourceSet;
-            string resourceId = parm.ResourceId;            
-            
+            string resourceId = parm.ResourceId;
+
             var items = Manager.GetResourceItems(resourceId, resourceSet, true).ToList();
             var itemList = new List<ResourceItemEx>();
 
@@ -346,7 +347,7 @@ namespace Westwind.Globalization.Administration
         }
 
 
-        protected IEnumerable<ResourceString> GetResourceStringsInternal(string resourceId, string resourceSet)        
+        protected IEnumerable<ResourceString> GetResourceStringsInternal(string resourceId, string resourceSet)
         {
             Dictionary<string, string> resources = Manager.GetResourceStrings(resourceId, resourceSet, true);
 
@@ -478,7 +479,7 @@ namespace Westwind.Globalization.Administration
             var resourceSet = Request.Form["ResourceSet"];
             var localeId = Request.Form["LocaleId"];
 
-            
+
 
             if (string.IsNullOrEmpty(resourceId) || string.IsNullOrEmpty(resourceSet))
                 throw new ApplicationException("Resourceset or ResourceId are not provided for upload.");
@@ -498,14 +499,14 @@ namespace Westwind.Globalization.Administration
             using (var fs = file.OpenReadStream())
             using (var ms = new MemoryStream())
             {
-                fs.CopyTo(ms);                
+                fs.CopyTo(ms);
                 ms.Flush();
 
                 if (DbResourceDataManager.SetFileDataOnResourceItem(item, ms.ToArray(), file.FileName) == null)
                     return false;
 
                 int res = Manager.UpdateOrAddResource(item);
-                if (res < 0)                    
+                if (res < 0)
                     return false;
             }
 
@@ -533,7 +534,7 @@ namespace Westwind.Globalization.Administration
         }
 
         /// <summary>
-        /// Delete an individual resource. Pass resourceId, resourceSet and localeId 
+        /// Delete an individual resource. Pass resourceId, resourceSet and localeId
         /// as a map. If localeId is null all the resources are deleted.
         /// </summary>
         /// <param name="parm"></param>
@@ -567,12 +568,12 @@ namespace Westwind.Globalization.Administration
 
         /// <summary>
         /// Renames a resource key to a new name.
-        /// 
+        ///
         /// Requires a JSON object with the following properties:
         /// {
         /// }
-        /// 
-        /// 
+        ///
+        ///
         /// </summary>
         /// <param name="parms"></param>
         /// <returns></returns>
@@ -682,7 +683,7 @@ namespace Westwind.Globalization.Administration
 
         #region Miscellaneous helpers
         [HttpPost]
-        [Route("Translate")]        
+        [Route("Translate")]
         public string Translate([FromBody] dynamic parm)
         {
             string text = parm.text;
@@ -701,7 +702,7 @@ namespace Westwind.Globalization.Administration
             else if (service == "bing")
             {
                 if (string.IsNullOrEmpty(DbResourceConfiguration.Current.BingClientId))
-                    result = ""; // don't do anything -  just return blank 
+                    result = ""; // don't do anything -  just return blank
                 else
                     result = translate.TranslateBing(text, from, to);
             }
@@ -709,7 +710,7 @@ namespace Westwind.Globalization.Administration
             {
                 result = translate.TranslateDeepL(text, from, to);
             }
-            
+
             if (result == null)
                 result = translate.ErrorMessage;
 
@@ -809,7 +810,7 @@ namespace Westwind.Globalization.Administration
 
                 Os = System.Runtime.InteropServices.RuntimeInformation.OSDescription,
                 AspNetVersion = v.ToString()
-                
+
             },jsonSettings);
         }
 
@@ -865,13 +866,13 @@ namespace Westwind.Globalization.Administration
 
             if (string.IsNullOrEmpty(nameSpace))
                 nameSpace = config.ResourceBaseNamespace;
-            
+
             if (!string.IsNullOrEmpty(strongTypes.ErrorMessage))
                 throw new ApplicationException(DbIRes.T("StronglyTypedGlobalResourcesFailed", STR_RESOURCESET));
 
             if (classType != "Resx")
                 strongTypes.CreateClassFromAllDatabaseResources(nameSpace, filename, resourceSets);
-            else             
+            else
             {
                 string outputBasePath = filename;
 
@@ -889,7 +890,7 @@ namespace Westwind.Globalization.Administration
 #if NETFULL
                     // Use automated generation
                     str.CreateResxDesignerClassFromResxFile(file, resource, nameSpace, false);
-#else                    
+#else
                     // Manual code generation
                     str.CreateResxDesignerClassFromResourceSet(resource, nameSpace,resource, file);
 #endif
@@ -930,17 +931,17 @@ namespace Westwind.Globalization.Administration
 
             if (outputBasePath.StartsWith("~"))
                 outputBasePath = Request.MapPath(outputBasePath, basePath: Host.ContentRootPath );
-            
+
             outputBasePath = FileUtils.NormalizePath(outputBasePath);
-                                           
+
             DbResXConverter exporter = new DbResXConverter(outputBasePath);
-                      
+
 
 
             // if resourceSets is null all resources are generated
             if (!exporter.GenerateResXFiles(resourceSets))
                 throw new ApplicationException(DbIRes.T("ResourceGenerationFailed", STR_RESOURCESET));
-          
+
             return true;
         }
 

--- a/src/NetCore/Westwind.Globalization.Test.NetCore/DbResourceMySqlDataManagerTests .cs
+++ b/src/NetCore/Westwind.Globalization.Test.NetCore/DbResourceMySqlDataManagerTests .cs
@@ -87,7 +87,7 @@ namespace Westwind.Globalization.Test
         {
             var manager = GetManager();
 
-            var items = manager.GetAllResourceIds("Resources");
+            var items = manager.GetAllResourceIds("Resources", "");
             Assert.IsNotNull(items,manager.ErrorMessage);
             Assert.IsTrue(items.Count > 0);
         }
@@ -97,7 +97,7 @@ namespace Westwind.Globalization.Test
         public void GetAllResourceIdListItems()
         {
             var manager = GetManager();
-            var items = manager.GetAllResourceIdListItems("Resources");
+            var items = manager.GetAllResourceIdListItems("Resources", "");
 
             Assert.IsNotNull(items);
             Assert.IsTrue(items.Count > 0);

--- a/src/NetCore/Westwind.Globalization.Test.NetCore/DbResourceSqLiteServerDataManagerTests.cs
+++ b/src/NetCore/Westwind.Globalization.Test.NetCore/DbResourceSqLiteServerDataManagerTests.cs
@@ -122,7 +122,7 @@ namespace Westwind.Globalization.Test
         {
             var manager = GetManager();
 
-            var items = manager.GetAllResourceIds("Resources");
+            var items = manager.GetAllResourceIds("Resources", "");
             Assert.IsNotNull(items,manager.ErrorMessage);
             Assert.IsTrue(items.Count > 0);
         }
@@ -132,7 +132,7 @@ namespace Westwind.Globalization.Test
         public void GetAllResourceIdsForHtmlDisplay()
         {
             var manager = GetManager();
-            var items = manager.GetAllResourceIdListItems("Resources");
+            var items = manager.GetAllResourceIdListItems("Resources", "");
 
             Assert.IsNotNull(items);
             Assert.IsTrue(items.Count > 0);

--- a/src/NetCore/Westwind.Globalization.Test.NetCore/DbResourceSqlServerCeDataManagerTests.cs
+++ b/src/NetCore/Westwind.Globalization.Test.NetCore/DbResourceSqlServerCeDataManagerTests.cs
@@ -75,7 +75,7 @@ namespace Westwind.Globalization.Test
         {
             var manager = GetManager();
 
-            var items = manager.GetAllResourceIds("Resources");
+            var items = manager.GetAllResourceIds("Resources", "");
             Assert.IsNotNull(items,manager.ErrorMessage);
             Assert.IsTrue(items.Count > 0);
         }
@@ -85,7 +85,7 @@ namespace Westwind.Globalization.Test
         public void GetAllResourceIdsForHtmlDisplay()
         {
             var manager = GetManager();
-            var items = manager.GetAllResourceIdListItems("Resources");
+            var items = manager.GetAllResourceIdListItems("Resources", "");
 
             Assert.IsNotNull(items);
             Assert.IsTrue(items.Count > 0);

--- a/src/NetCore/Westwind.Globalization.Test.NetCore/DbResourceSqlServerDataManagerTests.cs
+++ b/src/NetCore/Westwind.Globalization.Test.NetCore/DbResourceSqlServerDataManagerTests.cs
@@ -59,7 +59,7 @@ namespace Westwind.Globalization.Test
         {
             var manager = GetManager();
 
-            var items = manager.GetAllResourceIds("Resources");
+            var items = manager.GetAllResourceIds("Resources", "");
             Assert.IsNotNull(items);
             Assert.IsTrue(items.Count > 0);
         }
@@ -69,7 +69,7 @@ namespace Westwind.Globalization.Test
         public void GetAllResourceIdsForHtmlDisplay()
         {
             var manager = GetManager();
-            var items = manager.GetAllResourceIdListItems("Resources");
+            var items = manager.GetAllResourceIdListItems("Resources", "");
 
             Assert.IsNotNull(items);
             Assert.IsTrue(items.Count > 0);

--- a/src/Westwind.Globalization/DbResourceDataManager/DbResourceDataManager.cs
+++ b/src/Westwind.Globalization/DbResourceDataManager/DbResourceDataManager.cs
@@ -1,10 +1,10 @@
-#region License
+﻿#region License
 /*
  **************************************************************
- *  Author: Rick Strahl 
+ *  Author: Rick Strahl
  *          (c) West Wind Technologies, 2009-2015
  *          http://www.west-wind.com/
- * 
+ *
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -14,10 +14,10 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -26,7 +26,7 @@
  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
- **************************************************************  
+ **************************************************************
 */
 #endregion
 
@@ -49,19 +49,19 @@ using Westwind.Utilities.Data;
 namespace Westwind.Globalization
 {
     public abstract class DbResourceDataManager : IDbResourceDataManager
-    {     
+    {
         /// <summary>
         /// Instance of the DbResourceConfiguration that can be overridden
         /// Defaults to the default instance - DbResourceConfiguration.Current
         /// </summary>
-        public DbResourceConfiguration Configuration { get; set;  }                        
+        public DbResourceConfiguration Configuration { get; set;  }
 
         /// <summary>
         /// Error message that can be checked after a method complets
         /// and returns a failure result.
         /// </summary>
         public string ErrorMessage { get; set;  }
-        
+
         /// <summary>
         /// Code used to create a database (if required) for the
         /// given data provider.
@@ -84,7 +84,7 @@ namespace Westwind.Globalization
         /// Creates an instance of the DbResourceDataManager based on configuration settings
         /// </summary>
         /// <returns></returns>
-        public static DbResourceDataManager CreateDbResourceDataManager(Type managerType = null, 
+        public static DbResourceDataManager CreateDbResourceDataManager(Type managerType = null,
                                                                         DbResourceConfiguration configuration = null)
         {
             if (managerType == null)
@@ -105,7 +105,7 @@ namespace Westwind.Globalization
         /// Create an instance of the provider based on the resource type
         /// </summary>
         /// <returns></returns>
-        public static DbResourceDataManager CreateDbResourceDataManager(DbResourceProviderTypes type, 
+        public static DbResourceDataManager CreateDbResourceDataManager(DbResourceProviderTypes type,
                                                                         DbResourceConfiguration configuration = null)
         {
             DbResourceDataManager manager;
@@ -151,7 +151,7 @@ namespace Westwind.Globalization
                 cultureName = string.Empty;
             if (resourceSet == null)
                 resourceSet = string.Empty;
-            
+
             string resourceFilter;
             resourceFilter = " ResourceSet=@ResourceSet";
 
@@ -182,9 +182,9 @@ namespace Westwind.Globalization
                         object resourceValue = reader["Value"] as string;
                         string resourceType = reader["Type"] as string;
                         int valueType = 0;
-                        
-                        valueType = Convert.ToInt32(reader["ValueType"]);                           
-                        
+
+                        valueType = Convert.ToInt32(reader["ValueType"]);
+
                         if (!string.IsNullOrWhiteSpace(resourceType))
                         {
                             try
@@ -228,7 +228,7 @@ namespace Westwind.Globalization
                 finally
                 {
                     // close reader and connection
-                    reader.Close(); 
+                    reader.Close();
                 }
             }
 
@@ -241,14 +241,14 @@ namespace Westwind.Globalization
             {
                 if (valueType == resourceSetValueConverter.ValueType)
                     resourceValue = resourceSetValueConverter.Convert(resourceValue, key);
-            }            
+            }
         }
 
 
         /// <summary>
         /// Returns a fully normalized list of resources that contains the most specific
         /// locale version for the culture provided.
-        ///                 
+        ///
         /// This means that this routine walks the resource hierarchy and returns
         /// the most specific value in this order: de-ch, de, invariant.
         /// </summary>
@@ -318,7 +318,7 @@ namespace Westwind.Globalization
                             continue;
                         lastResourceId = resourceId;
 
-                        // Read the value into this                        
+                        // Read the value into this
                         object resourceValue = reader["Value"] as string;
                         string resourceType = reader["Type"] as string;
 
@@ -364,9 +364,9 @@ namespace Westwind.Globalization
                 throw new ArgumentException(Resources.InvalidFileExtensionForFileResource);
 
             string type;
-            if ("txt,css,htm,html,xml,js".Contains(ext))            
+            if ("txt,css,htm,html,xml,js".Contains(ext))
                 type = typeof(string).AssemblyQualifiedName;
-            
+
 
 #if NETFULL
             else if ("jpg,jpeg,png,gif,bmp".Contains(ext))
@@ -398,7 +398,7 @@ namespace Westwind.Globalization
 
         /// <summary>
         /// Internal method used to parse the data in the database into a 'real' value.
-        /// 
+        ///
         /// Value field hold filename and type string
         /// TextFile,BinFile hold the actual file content
         /// </summary>
@@ -426,7 +426,7 @@ namespace Westwind.Globalization
                         // to use the Bitmap later. Let CLR worry about garbage collection
                         // Prefer: Don't store jpegs
                         var ms = new MemoryStream(reader["BinFile"] as byte[]);
-                        value = new Bitmap(ms);                        
+                        value = new Bitmap(ms);
                     }
                     else
                     {
@@ -438,7 +438,7 @@ namespace Westwind.Globalization
                 }
                 else if (TypeInfo.Contains("System.Drawing.Icon"))
                 {
-                    // IMPORTANT: don't release the mem stream 
+                    // IMPORTANT: don't release the mem stream
                     var ms = new MemoryStream(reader["BinFile"] as byte[]);
                     value = new Icon(ms);
                 }
@@ -457,16 +457,16 @@ namespace Westwind.Globalization
         }
 
         /// <summary>
-        /// Returns a list of all the resources for all locales. The result is in a 
+        /// Returns a list of all the resources for all locales. The result is in a
         /// table called TResources that contains all fields of the table. The table is
         /// ordered by LocaleId.
-        /// 
+        ///
         /// This version returns either local or global resources in a Web app
-        /// 
+        ///
         /// Fields:
         /// ResourceId,Value,LocaleId,ResourceSet,Type
         /// </summary>
-        /// <param name="localResources">return local resources if true</param>        
+        /// <param name="localResources">return local resources if true</param>
         /// <returns></returns>
         public virtual List<ResourceItem> GetAllResources(bool localResources = false, bool applyValueConverters = false, string resourceSet = null)
         {
@@ -493,7 +493,7 @@ namespace Westwind.Globalization
                 items = data.Query<ResourceItem>(sql, parms.ToArray());
 
 
-                
+
                 if (items == null)
                 {
                     ErrorMessage = data.ErrorMessage;
@@ -513,41 +513,54 @@ namespace Westwind.Globalization
                         }
                     }
                 }
-                
+
                 return itemList;
             }
         }
 
-        
+
         /// <summary>
-        /// Returns all available resource ids for a given resource set in all languages.
-        /// 
-        /// Returns a ResourceIdItem object with ResourecId and HasValue fields.
+        /// Returns all available resource ids for the invariant.
+        ///
+        /// Returns a ResourceIdItem object with ResourceId, HasValue and NeedsUpdate fields.
         /// HasValue returns whether there are any entries in any culture for this
         /// resourceId
+        /// NeedsUpdate returns whether the target locale translation is missing
+        /// or older than the invariant if the targetLocaleId is specified.
+        ///
         /// </summary>
         /// <param name="resourceSet"></param>
+        /// <param name="targetLocaleId"></param>
         /// <returns></returns>
-        public virtual List<ResourceIdItem> GetAllResourceIds(string resourceSet)
-        {                      
+        public virtual List<ResourceIdItem> GetAllResourceIds(string resourceSet, string targetLocaleId)
+        {
             using (var data = GetDb())
             {
                 string sql = string.Format(
-//                    @"select ResourceId, CAST(MAX(len(Value)) as bit)  as HasValue
-//	  	from {0}
-//        where ResourceSet=@ResourceSet
-//		group by ResourceId", Configuration.ResourceTableName);
-                @"select ResourceId,CAST( MAX( 
-	  case  
-		WHEN len( CAST(Value as nvarchar(10))) > 0 THEN 1
-		ELSE 0
-	  end ) as Bit) as HasValue
-	  	from {0}
-        where ResourceSet=@ResourceSet 
-	    group by ResourceId",Configuration.ResourceTableName);
+                @"select ResourceId,
+                CAST( MAX(
+                    case
+                        WHEN len( CAST(Value as nvarchar(10))) > 0 THEN 1
+                        ELSE 0
+                    end ) as Bit) as HasValue
+                CAST( MAX(
+                    case
+                        WHEN l2.Updated IS NULL THEN 1
+                        WHEN l2.Updated <= l.Updated THEN 1
+                        ELSE 0
+                    end ) as BIT) as NeedsUpdate
+                from {0} l
+                left join {0} l2
+                on l2.ResourceId = l.ResourceId
+                and l2.ResourceSet = l.ResourceSet
+                and l2.LocaleId=@TargetLocaleId
+                where l.ResourceSet=@ResourceSet
+                and l.LocaleId=''", Configuration.ResourceTableName);
 
                 var items = data.Query<ResourceIdItem>(sql,
-                    data.CreateParameter("@ResourceSet", resourceSet));
+                    data.CreateParameter("@ResourceSet", resourceSet),
+                    data.CreateParameter("@TargetLocaleId", targetLocaleId)
+                );
                 if (items == null)
                 {
                     SetError(data.ErrorMessage);
@@ -559,14 +572,15 @@ namespace Westwind.Globalization
         }
 
         /// <summary>
-        /// Returns a list with ResourceId and HasValues fields
+        /// Returns a list with ResourceId, HasValue and NeedsUpdate fields
         /// where the ResourceId is formatted for HTML display.
         /// </summary>
         /// <param name="resourceSet"></param>
+        /// <param name="targetLocaleId"></param>
         /// <returns></returns>
-        public virtual List<ResourceIdListItem> GetAllResourceIdListItems(string resourceSet)
+        public virtual List<ResourceIdListItem> GetAllResourceIdListItems(string resourceSet, string targetLocaleId)
         {
-            var resourceIds = GetAllResourceIds(resourceSet);
+            var resourceIds = GetAllResourceIds(resourceSet, targetLocaleId);
             if (resourceIds == null)
                 return null;
 
@@ -574,6 +588,7 @@ namespace Westwind.Globalization
             {
                  ResourceId = id.ResourceId,
                  HasValue = id.HasValue,
+                 NeedsUpdate = id.NeedsUpdate,
                  Value = id.Value as string
             }).ToList();
             
@@ -631,7 +646,7 @@ namespace Westwind.Globalization
                     return null;
                 }
 
-                var items = new List<string>();                
+                var items = new List<string>();
 
                 while (dt.Read())
                 {
@@ -646,7 +661,7 @@ namespace Westwind.Globalization
 
         /// <summary>
         /// Gets all the locales for a specific resource set.
-        /// 
+        ///
         /// Returns a table named TLocaleIds (LocaleId field)
         /// </summary>
         /// <param name="ResourceSet"></param>
@@ -666,7 +681,7 @@ namespace Westwind.Globalization
                     return null;
 
                 var ids = new List<string>();
-                
+
 
                 while (reader.Read())
                 {
@@ -681,7 +696,7 @@ namespace Westwind.Globalization
 
         /// <summary>
         /// Gets all the Resourecs and ResourceIds for a given resource set and Locale
-        /// 
+        ///
         /// returns a table "TResource" ResourceId, Value fields
         /// </summary>
         /// <param name="resourceSet"></param>
@@ -694,7 +709,7 @@ namespace Westwind.Globalization
 
             using (var data = GetDb())
             {
-                var reader = 
+                var reader =
                     data.ExecuteReader(
                         "select ResourceId, Value from " + Configuration.ResourceTableName + " where ResourceSet=@ResourceSet and LocaleId=@LocaleId",
                         data.CreateParameter("@ResourceSet", resourceSet),
@@ -704,7 +719,7 @@ namespace Westwind.Globalization
                     return null;
 
                 var ids = new List<ResourceIdItem>();
-                
+
                 while (reader.Read())
                 {
                     string id = reader["ResourceId"] as string;
@@ -725,7 +740,7 @@ namespace Westwind.Globalization
         /// Returns an individual Resource String from the database
         /// </summary>
         /// <param name="resourceId"></param>
-        /// <param name="resourceSet"></param>       
+        /// <param name="resourceSet"></param>
         /// <param name="cultureName"></param>
         /// <returns></returns>
         public virtual string GetResourceString(string resourceId, string resourceSet, string cultureName)
@@ -753,7 +768,7 @@ namespace Westwind.Globalization
         /// Returns an object from the Resources. Attempts to convert the object to its
         /// original type.  Use this for any non-string  types. Useful for binary resources
         /// like images, icons etc.
-        /// 
+        ///
         /// While this method can be used with strings, GetResourceString()
         /// is much more efficient.
         /// </summary>
@@ -835,7 +850,7 @@ namespace Westwind.Globalization
                     reader.Close();
                 }
             }
-            
+
             return item;
         }
 
@@ -853,7 +868,7 @@ namespace Westwind.Globalization
 
             if (resourceSet == null)
                 resourceSet = string.Empty;
-            
+
             List<ResourceItem> items = null;
 
             using (var data = GetDb())
@@ -871,7 +886,7 @@ namespace Westwind.Globalization
                         SetError(data.ErrorMessage);
                         return null;
                     }
-                        
+
 
                     items = new List<ResourceItem>();
                     while (reader.Read())
@@ -893,7 +908,7 @@ namespace Westwind.Globalization
                         var emptyLocales = locales.Where(s => !usedLocales.Contains(s));
                         foreach (var locale in emptyLocales)
                         {
-                            items.Add(new ResourceItem(){ 
+                            items.Add(new ResourceItem(){
                                  LocaleId = locale,
                                  Value = "",
                                  ResourceSet = resourceSet
@@ -951,7 +966,7 @@ namespace Westwind.Globalization
 
             }
 
-            
+
 
             return Resources;
         }
@@ -976,7 +991,7 @@ namespace Westwind.Globalization
                     return locales;
                 }
             }
-            
+
             return null;
         }
 
@@ -1015,7 +1030,7 @@ namespace Westwind.Globalization
         /// <param name="value"></param>
         /// <param name="cultureName"></param>
         /// <param name="resourceSet"></param>
-        /// <param name="Type"></param>        
+        /// <param name="Type"></param>
         public virtual int UpdateOrAddResource(string resourceId, object value, string cultureName, string resourceSet,
             string comment = null, bool valueIsFileName = false, int valueType = 0)
         {
@@ -1045,7 +1060,7 @@ namespace Westwind.Globalization
         /// <summary>
         /// Adds a resource to the Localization Table
         /// </summary>
-        /// <param name="resource">Resource to update</param>        
+        /// <param name="resource">Resource to update</param>
         public virtual int AddResource(ResourceItem resource)
         {
             string Type = string.Empty;
@@ -1121,7 +1136,7 @@ namespace Westwind.Globalization
         /// <param name="valueIsFileName">if true the Value property is a filename to import</param>
         public virtual int AddResource(string resourceId, object value,
                                        string cultureName, string resourceSet,
-                                       string comment = null, bool valueIsFileName = false, 
+                                       string comment = null, bool valueIsFileName = false,
                                        int valueType = 0)
         {
             string Type = string.Empty;
@@ -1140,7 +1155,7 @@ namespace Westwind.Globalization
                 Type = value.GetType().AssemblyQualifiedName;
                 try
                 {
-                    SerializeValue(value);                                        
+                    SerializeValue(value);
                 }
                 catch (Exception ex)
                 {
@@ -1235,7 +1250,7 @@ namespace Westwind.Globalization
         /// <param name="cultureName"></param>
         /// <param name="resourceSet"></param>
         /// <param name="Type"></param>
-        public virtual int UpdateResource(string resourceId, object value, 
+        public virtual int UpdateResource(string resourceId, object value,
                                           string cultureName, string resourceSet,
                                           string comment = null, bool valueIsFileName = false,
                                           int valueType = 0)
@@ -1375,7 +1390,7 @@ namespace Westwind.Globalization
             }
 
 
-          
+
             if (resource.Value == null)
                 resource.Value = string.Empty;
 
@@ -1416,7 +1431,7 @@ namespace Westwind.Globalization
             return result;
 
         }
-        
+
 
         /// <summary>
         /// Internal routine that looks at a file and based on its
@@ -1471,16 +1486,16 @@ namespace Westwind.Globalization
             else
             {
                 fileInfo.FileFormatType = FileFormatTypes.Binary;
-                fileInfo.Type = "FileResource"; 
+                fileInfo.Type = "FileResource";
                 if (!noPhysicalFile)
-                    fileInfo.BinContent = File.ReadAllBytes(fileName);                
+                    fileInfo.BinContent = File.ReadAllBytes(fileName);
                 fileInfo.ValueString = fileInfo.FileName + ";" + typeof(Byte[]).AssemblyQualifiedName;
             }
 
             return fileInfo;
         }
 
-    
+
 
 
         /// <summary>
@@ -1538,9 +1553,9 @@ namespace Westwind.Globalization
         {
             using (var data = GetDb())
             {
-                var result = data.ExecuteNonQuery("update " + Configuration.ResourceTableName + 
-                                                  " set ResourceId=@NewResourceId where ResourceId=@ResourceId AND ResourceSet=@ResourceSet", 
-                    data.CreateParameter("@ResourceId", ResourceId), 
+                var result = data.ExecuteNonQuery("update " + Configuration.ResourceTableName +
+                                                  " set ResourceId=@NewResourceId where ResourceId=@ResourceId AND ResourceSet=@ResourceSet",
+                    data.CreateParameter("@ResourceId", ResourceId),
                     data.CreateParameter("@NewResourceId", NewResourceId),
                     data.CreateParameter("@ResourceSet", ResourceSet));
                 if (result == -1)
@@ -1555,7 +1570,7 @@ namespace Westwind.Globalization
                 }
             }
 
-            
+
 
             return true;
         }
@@ -1605,7 +1620,7 @@ namespace Westwind.Globalization
             {
                 int result;
                 if (cultureName == null)
-                    result = data.ExecuteNonQuery("delete from " + Configuration.ResourceTableName + 
+                    result = data.ExecuteNonQuery("delete from " + Configuration.ResourceTableName +
                                                 " where ResourceSet=@ResourceSet",
                                                 data.CreateParameter("@ResourceSet", ResourceSet));
                 else
@@ -1631,10 +1646,10 @@ namespace Westwind.Globalization
         /// <summary>
         /// Renames a resource set. Useful if you need to move a local page resource set
         /// to a new page. ResourceSet naming for local resources is application relative page path:
-        /// 
+        ///
         /// test.aspx
         /// subdir/test.aspx
-        /// 
+        ///
         /// Global resources have a simple name
         /// </summary>
         /// <param name="OldResourceSet">Name of the existing resource set</param>
@@ -1677,7 +1692,7 @@ namespace Westwind.Globalization
 
             using (var Data = GetDb())
             {
-                var result = Data.ExecuteScalar("select ResourceId from " + Configuration.ResourceTableName + 
+                var result = Data.ExecuteScalar("select ResourceId from " + Configuration.ResourceTableName +
                                                 " where ResourceId=@ResourceId and LocaleID=@LocaleId and ResourceSet=@ResourceSet group by ResourceId",
                     Data.CreateParameter("@ResourceId", ResourceId),
                     Data.CreateParameter("@LocaleId", CultureName),
@@ -1778,9 +1793,9 @@ namespace Westwind.Globalization
 
 
         /// <summary>
-        /// Creates an global JavaScript object object that holds all non-control 
+        /// Creates an global JavaScript object object that holds all non-control
         /// local string resources as property values.
-        /// 
+        ///
         /// All resources are returned in normalized fashion from most specifc
         /// to more generic (de-ch,de,invariant depending on availability)
         /// </summary>
@@ -1797,16 +1812,16 @@ namespace Westwind.Globalization
             IDictionary resources = GetResourceSetNormalizedForLocaleId(
                 localeId, resourceSet);
 
-            // Filter the list to non-control resources 
+            // Filter the list to non-control resources
             Dictionary<string, string> localRes = new Dictionary<string, string>();
             foreach (string key in resources.Keys)
             {
-                // We're only interested in non control local resources 
+                // We're only interested in non control local resources
                 if (!key.Contains(".") && resources[key] is string)
                     localRes.Add(key, resources[key] as string);
             }
 
-            var json = JsonConvert.SerializeObject(localRes, Formatting.Indented);            
+            var json = JsonConvert.SerializeObject(localRes, Formatting.Indented);
             return "var " + javaScriptVarName + " = " + json + ";\r\n";
         }
 
@@ -1822,9 +1837,9 @@ namespace Westwind.Globalization
                 tableName = Configuration.ResourceTableName;
             if (string.IsNullOrEmpty(tableName))
                 tableName = "Localizations";
-            
+
             string sql = "SELECT * FROM INFORMATION_SCHEMA.TABLES where TABLE_NAME=@0";
-        
+
             using (var data = GetDb())
             {
                 var tables = data.ExecuteTable("TTables", sql, tableName);
@@ -1842,7 +1857,7 @@ namespace Westwind.Globalization
 
         /// <summary>
         /// Create a backup of the localization database.
-        /// 
+        ///
         /// Note the table used is the one specified in the Configuration.ResourceTableName
         /// </summary>
         /// <param name="BackupTableName">Table of the backup table. Null creates a _Backup table.</param>
@@ -1867,7 +1882,7 @@ namespace Westwind.Globalization
 
 
         /// <summary>
-        /// Restores the localization table from a backup table by first wiping out 
+        /// Restores the localization table from a backup table by first wiping out
         /// </summary>
         /// <param name="backupTableName"></param>
         /// <returns></returns>
@@ -1890,7 +1905,7 @@ namespace Westwind.Globalization
 
                 string sql =
                     @"insert into {0}
-  (ResourceId,Value,LocaleId,ResourceSet,Type,BinFile,TextFile,FileName,Comment) 
+  (ResourceId,Value,LocaleId,ResourceSet,Type,BinFile,TextFile,FileName,Comment)
    select ResourceId,Value,LocaleId,ResourceSet,Type,BinFile,TextFile,FileName,Comment from {1}";
 
                 sql = string.Format(sql, Configuration.ResourceTableName, backupTableName);
@@ -1924,7 +1939,7 @@ namespace Westwind.Globalization
 
             string Sql = string.Format(TableCreationSql, tableName);
 
-            
+
             // Check for table existing already
             if (IsLocalizationTable(tableName))
             {
@@ -1959,7 +1974,7 @@ namespace Westwind.Globalization
 
         /// <summary>
         /// Deserializes serialized data in JSON format based on a
-        /// type name provided in the resource type parameter.        
+        /// type name provided in the resource type parameter.
         /// </summary>
         /// <param name="serializedValue">JSON encoded string</param>
         /// <param name="resourceType">Type name to deserialize - type must be referenced by the app</param>
@@ -1972,7 +1987,7 @@ namespace Westwind.Globalization
 
             return JsonConvert.DeserializeObject(serializedValue,type);
         }
-       
+
         public void SetError()
         {
             SetError("CLEAR");
@@ -2017,11 +2032,12 @@ namespace Westwind.Globalization
 
     /// <summary>
     /// Short form ResourceItem for passing Ids
-    /// </summary>    
+    /// </summary>
     public class ResourceIdItem
     {
         public string ResourceId { get; set; }
         public bool HasValue { get; set; }
+        public bool NeedsUpdate { get; set; }
         public object Value { get; set; }
         public override string ToString()
         {
@@ -2064,7 +2080,7 @@ namespace Westwind.Globalization
     /// <summary>
     /// Sets the DbResourceProviderType based on a simple enum value. Provided
     /// merely as a proxy for setting the actual type.
-    /// 
+    ///
     /// Use **Custom** if you want to use a custom provider that you created
     /// and that's not listed here.
     /// </summary>
@@ -2075,12 +2091,12 @@ namespace Westwind.Globalization
         SqLite,
         SqlServerCompact,
         Custom,
-        NotSet        
+        NotSet
     }
 
     /// <summary>
     /// Internal structure that contains format information about a file
-    /// resource. Used internally to figure out how to write 
+    /// resource. Used internally to figure out how to write
     /// a resource into the database
     /// </summary>
     public class FileInfoFormat

--- a/src/Westwind.Globalization/DbResourceDataManager/IDbResourceDataManager.cs
+++ b/src/Westwind.Globalization/DbResourceDataManager/IDbResourceDataManager.cs
@@ -1,8 +1,8 @@
-#region License
+﻿#region License
 /*
  **************************************************************
  *  Author: Rick Strahl 
- *          � West Wind Technologies, 2009-2015
+ *          © West Wind Technologies, 2009-2015
  *          http://www.west-wind.com/
  * 
  *
@@ -94,23 +94,28 @@ namespace Westwind.Globalization
         List<ResourceItem> GetAllResources(bool localResources = false, bool applyValueConverters = false, string resourceSet = null);
 
         /// <summary>
-        /// Returns all available resource ids for a given resource set in all languages.
-        /// 
-        /// Returns a ResourceIdItem object with ResourecId and HasValue fields.
+        /// Returns all available resource ids for the invariant.
+        ///
+        /// Returns a ResourceIdItem object with ResourceId, HasValue and NeedsUpdate fields.
         /// HasValue returns whether there are any entries in any culture for this
         /// resourceId
+        /// NeedsUpdate returns whether the target locale translation is missing
+        /// or older than the invariant if the targetLocaleId is specified.
+        /// 
         /// </summary>
         /// <param name="resourceSet"></param>
+        /// <param name="targetLocaleId"></param>
         /// <returns></returns>
-        List<ResourceIdItem> GetAllResourceIds(string resourceSet);
+        List<ResourceIdItem> GetAllResourceIds(string resourceSet, string targetLocaleId);
 
         /// <summary>
-        /// Returns an DataTable called TResourceIds with ResourceId and HasValues fields
+        /// Returns an DataTable called TResourceIds with ResourceId, HasValue and NeedsUpdate fields
         /// where the ResourceId is formatted for HTML display.
         /// </summary>
         /// <param name="resourceSet"></param>
+        /// <param name="targetLocaleId"></param>
         /// <returns></returns>
-        List<ResourceIdListItem> GetAllResourceIdListItems(string resourceSet);
+        List<ResourceIdListItem> GetAllResourceIdListItems(string resourceSet, string targetLocaleId);
 
         /// <summary>
         /// Returns all available resource sets


### PR DESCRIPTION
This PR provides the ability for the LocalizationAdmin to show a user if a particular ResourceId in the list needs attention, if that resource is older than the invariant or not present. I can include changes to the sample admin client as well that allow a user to select the target locale for translation which is the only way this feature is useful.

It seems reasonable that generally a translator is only working on one language at a time, so having the user select that language helps the translator focus on his specific work items without the clutter of seeing all languages the app is translated into.