### PR TITLE
Case sensitivity fix for get JavaScriptLocalizationResources api call

### DIFF
--- a/src/Westwind.Globalization/DbResourceDataManager/DbResourceDataManager.cs
+++ b/src/Westwind.Globalization/DbResourceDataManager/DbResourceDataManager.cs
@@ -271,7 +271,7 @@ namespace Westwind.Globalization
                   DbDataReader reader = null;
 
                 string sql =
-                    @"select resourceId, LocaleId, Value, Type, BinFile, TextFile, FileName
+                    @"select ResourceId, LocaleId, Value, Type, BinFile, TextFile, FileName
     from " + Configuration.ResourceTableName + @"
 	where ResourceSet=@ResourceSet and (LocaleId = '' {0} )
     order by ResourceId, LocaleId DESC";


### PR DESCRIPTION
JavaScriptLocalizationResources api call does not return any result on a case sensitive Sql Server database as we do not have resourceId column.